### PR TITLE
Create directories for new files from a tar

### DIFF
--- a/pkg/oci/download.go
+++ b/pkg/oci/download.go
@@ -112,6 +112,13 @@ func untarToDirectory(destination string, tarReader io.Reader) error {
 
 		// if it's a file create it
 		case tar.TypeReg:
+			targetDir := filepath.Dir(target)
+			if _, err := os.Stat(targetDir); os.IsNotExist(err) {
+				if err := os.MkdirAll(targetDir, 0755); err != nil {
+					return err
+				}
+			}
+
 			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
 			if err != nil {
 				return err


### PR DESCRIPTION
Currently we need to create all directories for a tar file, but we won't necessarily know what they are upfront. This means any file that should be created from an untar will make sure directory structures needed are created too. This happens in our policies tars currently.